### PR TITLE
🧹 remove commented-out code in Room-Mailbox.ps1

### DIFF
--- a/Room-Mailbox.ps1
+++ b/Room-Mailbox.ps1
@@ -569,7 +569,6 @@ write-host
 # Section 3: PowerShell Command
 
 Set-CalendarProcessing $ROOMMB -AutomateProcessing AutoAccept
-# Set-CalendarProcessing <Room> -AutomateProcessing AutoAccept
 # Section 4:  Indication 
 
 write-host


### PR DESCRIPTION
🎯 **What:** Removed a redundant commented-out code snippet in `Room-Mailbox.ps1` at line 572.
💡 **Why:** The commented-out code was a template version of an existing command, and removing it reduces clutter and improves readability.
✅ **Verification:** Confirmed the removal by reading the file content and performing a manual syntax check.
✨ **Result:** A cleaner and more maintainable script.

---
*PR created automatically by Jules for task [14646165969513144758](https://jules.google.com/task/14646165969513144758) started by @flatlinebb*