### PR TITLE
⚡ Optimize MSOL user fetching and report generation

### DIFF
--- a/MailboxSizeReport_new.ps1
+++ b/MailboxSizeReport_new.ps1
@@ -12,21 +12,37 @@ $Mailboxes = Get-Mailbox -ResultSize Unlimited | where {$_.RecipientTypeDetails 
 $MSOLDomain = Get-MsolDomain | where {$_.Authentication -eq "Managed" -and $_.IsDefault -eq "True"}
 $MSOLPasswordPolicy = Get-MsolPasswordPolicy -DomainName $MSOLDomain.name
 $MSOLPasswordPolicy = $MSOLPasswordPolicy.ValidityPeriod.ToString()
-foreach ($mailbox in $Mailboxes) {
-$DaysToExpiry = @()
-$DisplayName = $mailbox.DisplayName
-$UserPrincipalName  = $mailbox.UserPrincipalName
-$UserDomain = $UserPrincipalName.Split('@')[1]
-$Alias = $mailbox.alias
-$MailboxStat = Get-MailboxStatistics $UserPrincipalName
-$LastLogonTime = $MailboxStat.LastLogonTime 
-$TotalItemSize = $MailboxStat | select @{name="TotalItemSize";expression={[math]::Round(($_.TotalItemSize.ToString().Split("(")[1].Split(" ")[0].Replace(",","")/1MB),2)}}
-$TotalItemSize = $TotalItemSize.TotalItemSize
-$RecipientTypeDetails = $mailbox.RecipientTypeDetails
-$MSOLUSER = Get-MsolUser -UserPrincipalName $UserPrincipalName
-if ($UserDomain -eq $MSOLDomain.name) {$DaysToExpiry = $MSOLUSER |  select @{Name="DaysToExpiry"; Expression={(New-TimeSpan -start (get-date) -end ($_.LastPasswordChangeTimestamp + $MSOLPasswordPolicy)).Days}}; $DaysToExpiry = $DaysToExpiry.DaysToExpiry}
-$Information = $MSOLUSER | select FirstName,LastName,@{Name='DisplayName'; Expression={[String]::join(";", $DisplayName)}},@{Name='Alias'; Expression={[String]::join(";", $Alias)}},@{Name='UserPrincipalName'; Expression={[String]::join(";", $UserPrincipalName)}},Office,Department,@{Name='TotalItemSize (MB)'; Expression={[String]::join(";", $TotalItemSize)}},@{Name='LastLogonTime'; Expression={[String]::join(";", $LastLogonTime)}},LastPasswordChangeTimestamp,@{Name="PasswordExpirationIn (Days)"; Expression={[String]::join(";", $DaysToExpiry)}},@{Name='RecipientTypeDetails'; Expression={[String]::join(";", $RecipientTypeDetails)}},islicensed,@{Name="Licenses"; Expression ={$_.Licenses.AccountSkuId}} 
-$Report = $Report+$Information
+
+# Optimization: Fetch all MSOL users upfront to avoid N+1 query issue
+$AllMSOLUsers = Get-MsolUser -All
+$MSOLUserLookup = @{}
+foreach ($user in $AllMSOLUsers) {
+    $MSOLUserLookup[$user.UserPrincipalName] = $user
+}
+
+# Optimization: Assign loop output directly to $Report to avoid inefficient array concatenation
+$Report = foreach ($mailbox in $Mailboxes) {
+    $DaysToExpiry = @()
+    $DisplayName = $mailbox.DisplayName
+    $UserPrincipalName  = $mailbox.UserPrincipalName
+    $UserDomain = $UserPrincipalName.Split('@')[1]
+    $Alias = $mailbox.alias
+    $MailboxStat = Get-MailboxStatistics $UserPrincipalName
+    $LastLogonTime = $MailboxStat.LastLogonTime
+    $TotalItemSize = $MailboxStat | select @{name="TotalItemSize";expression={[math]::Round(($_.TotalItemSize.ToString().Split("(")[1].Split(" ")[0].Replace(",","")/1MB),2)}}
+    $TotalItemSize = $TotalItemSize.TotalItemSize
+    $RecipientTypeDetails = $mailbox.RecipientTypeDetails
+
+    # Optimization: Use lookup table instead of per-user query
+    $MSOLUSER = $MSOLUserLookup[$UserPrincipalName]
+
+    if ($UserDomain -eq $MSOLDomain.name) {
+        $DaysToExpiry = $MSOLUSER |  select @{Name="DaysToExpiry"; Expression={(New-TimeSpan -start (get-date) -end ($_.LastPasswordChangeTimestamp + $MSOLPasswordPolicy)).Days}}
+        $DaysToExpiry = $DaysToExpiry.DaysToExpiry
+    }
+
+    # Output the Information object to the loop's output stream
+    $MSOLUSER | select FirstName,LastName,@{Name='DisplayName'; Expression={[String]::join(";", $DisplayName)}},@{Name='Alias'; Expression={[String]::join(";", $Alias)}},@{Name='UserPrincipalName'; Expression={[String]::join(";", $UserPrincipalName)}},Office,Department,@{Name='TotalItemSize (MB)'; Expression={[String]::join(";", $TotalItemSize)}},@{Name='LastLogonTime'; Expression={[String]::join(";", $LastLogonTime)}},LastPasswordChangeTimestamp,@{Name="PasswordExpirationIn (Days)"; Expression={[String]::join(";", $DaysToExpiry)}},@{Name='RecipientTypeDetails'; Expression={[String]::join(";", $RecipientTypeDetails)}},islicensed,@{Name="Licenses"; Expression ={$_.Licenses.AccountSkuId}}
 }
 $Report | export-csv "C:\Temp\O365\Office365MailboxSizeReport.csv" -NoTypeInformation
 Import-CSV "C:\Temp\O365\Office365MailboxSizeReport.csv" | ConvertTo-Html -head $a -body "<html><body>O365 Report for Customer<br><img src=`"FM.gif`"></body></html>" | Out-File "C:\temp\O365\Office365MailboxSizeReport.html"


### PR DESCRIPTION
💡 **What:**
- Replaced per-mailbox `Get-MsolUser` calls with a single bulk fetch (`Get-MsolUser -All`) and a hashtable lookup.
- Optimized the `$Report` collection by assigning the loop output directly to the variable instead of using `$Report = $Report + $Information`.

🎯 **Why:**
- Fetching remote MSOL users individually inside a loop created a significant N+1 bottleneck, causing the script to be slow and inefficient due to network latency.
- Array concatenation with `+` in PowerShell is an O(N^2) operation because it creates a new array on every iteration, which becomes increasingly expensive as the report grows.

📊 **Measured Improvement:**
- While local benchmarking was not possible due to environment limitations, these changes address two well-known PowerShell performance anti-patterns.
- Reducing remote API calls from N to 1 provides a massive performance boost, especially for large tenants.
- Moving from O(N^2) to O(N) for array building significantly reduces memory allocation and CPU time for large datasets.

---
*PR created automatically by Jules for task [1458652599510256548](https://jules.google.com/task/1458652599510256548) started by @flatlinebb*