### PR TITLE
🔒 [security fix] Secure credential handling in MailboxSizeReport_new.ps1

### DIFF
--- a/MailboxSizeReport_new.ps1
+++ b/MailboxSizeReport_new.ps1
@@ -1,11 +1,25 @@
-cd C:\Temp\O365
-$password = Get-Content C:\Temp\O365\Office365cred.txt | ConvertTo-SecureString
-echo $password
-$cred = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList administrator@mbflegal.com,$password
-$s = New-PSSession -ConfigurationName Microsoft.Exchange -ConnectionUri https://ps.outlook.com/powershell -Credential $cred -Authentication Basic -AllowRedirection
+Param(
+    [Parameter(Mandatory=$false)]
+    [PSCredential]$Office365Credential,
+
+    [Parameter(Mandatory=$false)]
+    [string]$ReportPath = "C:\Temp\O365",
+
+    [Parameter(Mandatory=$false)]
+    [string]$ToEmail = "shudda@flexmanage.com",
+
+    [Parameter(Mandatory=$false)]
+    [string]$FromEmail = "administrator@mbflegal.com"
+)
+
+if ($null -eq $Office365Credential) {
+    $Office365Credential = Get-Credential
+}
+
+$s = New-PSSession -ConfigurationName Microsoft.Exchange -ConnectionUri https://ps.outlook.com/powershell -Credential $Office365Credential -Authentication Basic -AllowRedirection
 $importresults = Import-PSSession $s
-Import-Module msonline 
-Connect-MsolService -Credential $Cred
+Import-Module msonline
+Connect-MsolService -Credential $Office365Credential
 $date = Get-Date -Format "MM-dd-yyyy"
 $Report=@()
 $Mailboxes = Get-Mailbox -ResultSize Unlimited | where {$_.RecipientTypeDetails -ne "DiscoveryMailbox"}
@@ -19,18 +33,20 @@ $UserPrincipalName  = $mailbox.UserPrincipalName
 $UserDomain = $UserPrincipalName.Split('@')[1]
 $Alias = $mailbox.alias
 $MailboxStat = Get-MailboxStatistics $UserPrincipalName
-$LastLogonTime = $MailboxStat.LastLogonTime 
+$LastLogonTime = $MailboxStat.LastLogonTime
 $TotalItemSize = $MailboxStat | select @{name="TotalItemSize";expression={[math]::Round(($_.TotalItemSize.ToString().Split("(")[1].Split(" ")[0].Replace(",","")/1MB),2)}}
 $TotalItemSize = $TotalItemSize.TotalItemSize
 $RecipientTypeDetails = $mailbox.RecipientTypeDetails
 $MSOLUSER = Get-MsolUser -UserPrincipalName $UserPrincipalName
 if ($UserDomain -eq $MSOLDomain.name) {$DaysToExpiry = $MSOLUSER |  select @{Name="DaysToExpiry"; Expression={(New-TimeSpan -start (get-date) -end ($_.LastPasswordChangeTimestamp + $MSOLPasswordPolicy)).Days}}; $DaysToExpiry = $DaysToExpiry.DaysToExpiry}
-$Information = $MSOLUSER | select FirstName,LastName,@{Name='DisplayName'; Expression={[String]::join(";", $DisplayName)}},@{Name='Alias'; Expression={[String]::join(";", $Alias)}},@{Name='UserPrincipalName'; Expression={[String]::join(";", $UserPrincipalName)}},Office,Department,@{Name='TotalItemSize (MB)'; Expression={[String]::join(";", $TotalItemSize)}},@{Name='LastLogonTime'; Expression={[String]::join(";", $LastLogonTime)}},LastPasswordChangeTimestamp,@{Name="PasswordExpirationIn (Days)"; Expression={[String]::join(";", $DaysToExpiry)}},@{Name='RecipientTypeDetails'; Expression={[String]::join(";", $RecipientTypeDetails)}},islicensed,@{Name="Licenses"; Expression ={$_.Licenses.AccountSkuId}} 
+$Information = $MSOLUSER | select FirstName,LastName,@{Name='DisplayName'; Expression={[String]::join(";", $DisplayName)}},@{Name='Alias'; Expression={[String]::join(";", $Alias)}},@{Name='UserPrincipalName'; Expression={[String]::join(";", $UserPrincipalName)}},Office,Department,@{Name='TotalItemSize (MB)'; Expression={[String]::join(";", $TotalItemSize)}},@{Name='LastLogonTime'; Expression={[String]::join(";", $LastLogonTime)}},LastPasswordChangeTimestamp,@{Name="PasswordExpirationIn (Days)"; Expression={[String]::join(";", $DaysToExpiry)}},@{Name='RecipientTypeDetails'; Expression={[String]::join(";", $RecipientTypeDetails)}},islicensed,@{Name="Licenses"; Expression ={$_.Licenses.AccountSkuId}}
 $Report = $Report+$Information
 }
-$Report | export-csv "C:\Temp\O365\Office365MailboxSizeReport.csv" -NoTypeInformation
-Import-CSV "C:\Temp\O365\Office365MailboxSizeReport.csv" | ConvertTo-Html -head $a -body "<html><body>O365 Report for Customer<br><img src=`"FM.gif`"></body></html>" | Out-File "C:\temp\O365\Office365MailboxSizeReport.html"
-$attachment = Get-ChildItem C:\Temp\O365 | Where-Object { $_.Extension -eq ".html" } | Select-Object -Last 1
-$attachment1 = Get-ChildItem C:\Temp\O365 | Where-Object { $_.Extension -eq ".gif" } | Select-Object -Last 1
-Send-MailMessage -To shudda@flexmanage.com -From administrator@mbflegal.com -Subject "Monthly Office 365 Mailbox Size Report" -Body "The monthly mailbox size report is attached to this message as a CSV file." -SmtpServer outlook.office365.com -Credential $cred -UseSsl -Attachments $attachment,$attachment1
+$CsvPath = Join-Path $ReportPath "Office365MailboxSizeReport.csv"
+$HtmlPath = Join-Path $ReportPath "Office365MailboxSizeReport.html"
+$Report | export-csv $CsvPath -NoTypeInformation
+Import-CSV $CsvPath | ConvertTo-Html -head $a -body "<html><body>O365 Report for Customer<br><img src=`"FM.gif`"></body></html>" | Out-File $HtmlPath
+$attachment = Get-ChildItem $ReportPath | Where-Object { $_.Extension -eq ".html" } | Select-Object -Last 1
+$attachment1 = Get-ChildItem $ReportPath | Where-Object { $_.Extension -eq ".gif" } | Select-Object -Last 1
+Send-MailMessage -To $ToEmail -From $FromEmail -Subject "Monthly Office 365 Mailbox Size Report" -Body "The monthly mailbox size report is attached to this message as a CSV file." -SmtpServer outlook.office365.com -Credential $Office365Credential -UseSsl -Attachments $attachment,$attachment1
 Remove-PSSession $s


### PR DESCRIPTION
### 🎯 What
Removed hardcoded path to a plaintext credentials file (`C:\Temp\O365\Office365cred.txt`) and eliminated insecure password echoing in `MailboxSizeReport_new.ps1`.

### ⚠️ Risk
The original script stored and retrieved administrative credentials in plaintext from a fixed local directory, and explicitly echoed the password to the console. This posed a high risk of credential theft if the local machine was compromised or if console logs were intercepted.

### 🛡️ Solution
- Introduced a `Param` block to accept a `[PSCredential]` object, allowing for secure automation and interactive use.
- Implemented `Get-Credential` fallback for interactive prompting if credentials are not provided.
- Parameterized the report output path (`$ReportPath`) and email recipients (`$ToEmail`, `$FromEmail`), defaulting to original values but allowing override.
- Replaced hardcoded path concatenations with `Join-Path` for cross-platform robustness and security.
- Removed the insecure `echo $password` and hardcoded directory changes.

---
*PR created automatically by Jules for task [11839351180854860723](https://jules.google.com/task/11839351180854860723) started by @flatlinebb*