### PR TITLE
🔒 fix: secure PowerShell execution policy in O365ExchangeManage.ps1

### DIFF
--- a/O365ExchangeManage.ps1
+++ b/O365ExchangeManage.ps1
@@ -1,4 +1,4 @@
-Set-ExecutionPolicy Unrestricted
+Set-ExecutionPolicy RemoteSigned -Scope Process -Force
 Import-Module MSOnline
 $O365Cred = Get-Credential
 $O365Session = New-PSSession -ConfigurationName Microsoft.Exchange -ConnectionUri https://ps.outlook.com/powershell -Credential $O365Cred -Authentication Basic -AllowRedirection


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The `O365ExchangeManage.ps1` script previously set the execution policy globally to `Unrestricted`. This patch changes it to `RemoteSigned` and restricts the scope to the current `Process`.

⚠️ **Risk:** The potential impact if left unfixed
Setting the execution policy to `Unrestricted` globally allows any script (including malicious ones downloaded from the internet) to run on the system without warning, significantly weakening the system's security posture.

🛡️ **Solution:** How the fix addresses the vulnerability
The fix uses `Set-ExecutionPolicy RemoteSigned -Scope Process -Force`. This ensures that:
1. The execution policy change only applies to the current script execution (`-Scope Process`), preventing persistent global changes.
2. It requires remote scripts to be signed (`RemoteSigned`), which is a much safer default than `Unrestricted`.
3. It bypasses any prompts (`-Force`) to allow the script to continue running unattended as intended.

---
*PR created automatically by Jules for task [8214185172793494492](https://jules.google.com/task/8214185172793494492) started by @flatlinebb*