### PR TITLE
🧹 Remove outdated comment in RemoveTempFiles.ps1

### DIFF
--- a/RemoveTempFiles.ps1
+++ b/RemoveTempFiles.ps1
@@ -1,5 +1,3 @@
-# Remove the -Whatif parameters to use the commands below
-
 # Remove all temp files for current user
 Get-ChildItem $Env:Temp | Remove-Item -Recurse -Force
 


### PR DESCRIPTION
🎯 **What:** Removed the outdated comment `# Remove the -Whatif parameters to use the commands below` from `RemoveTempFiles.ps1`.
💡 **Why:** The commands in the script do not use the `-WhatIf` parameter. Leaving the comment there is confusing and incorrect.
✅ **Verification:** Verified visually by reading the script. No functional changes were made, only comments were removed. Tests cannot be run as there is no PowerShell environment in the sandbox.
✨ **Result:** Improved code readability by removing misleading comments.

---
*PR created automatically by Jules for task [12489457447340770976](https://jules.google.com/task/12489457447340770976) started by @flatlinebb*