### PR TITLE
⚡ Optimize MailboxSizeReport array concatenation

### DIFF
--- a/MailboxSizeReport_new.ps1
+++ b/MailboxSizeReport_new.ps1
@@ -21,12 +21,11 @@ $importresults = Import-PSSession $s
 Import-Module msonline
 Connect-MsolService -Credential $Office365Credential
 $date = Get-Date -Format "MM-dd-yyyy"
-$Report=@()
 $Mailboxes = Get-Mailbox -ResultSize Unlimited | where {$_.RecipientTypeDetails -ne "DiscoveryMailbox"}
 $MSOLDomain = Get-MsolDomain | where {$_.Authentication -eq "Managed" -and $_.IsDefault -eq "True"}
 $MSOLPasswordPolicy = Get-MsolPasswordPolicy -DomainName $MSOLDomain.name
 $MSOLPasswordPolicy = $MSOLPasswordPolicy.ValidityPeriod.ToString()
-foreach ($mailbox in $Mailboxes) {
+$Report = @(foreach ($mailbox in $Mailboxes) {
 $DaysToExpiry = @()
 $DisplayName = $mailbox.DisplayName
 $UserPrincipalName  = $mailbox.UserPrincipalName
@@ -40,8 +39,8 @@ $RecipientTypeDetails = $mailbox.RecipientTypeDetails
 $MSOLUSER = Get-MsolUser -UserPrincipalName $UserPrincipalName
 if ($UserDomain -eq $MSOLDomain.name) {$DaysToExpiry = $MSOLUSER |  select @{Name="DaysToExpiry"; Expression={(New-TimeSpan -start (get-date) -end ($_.LastPasswordChangeTimestamp + $MSOLPasswordPolicy)).Days}}; $DaysToExpiry = $DaysToExpiry.DaysToExpiry}
 $Information = $MSOLUSER | select FirstName,LastName,@{Name='DisplayName'; Expression={[String]::join(";", $DisplayName)}},@{Name='Alias'; Expression={[String]::join(";", $Alias)}},@{Name='UserPrincipalName'; Expression={[String]::join(";", $UserPrincipalName)}},Office,Department,@{Name='TotalItemSize (MB)'; Expression={[String]::join(";", $TotalItemSize)}},@{Name='LastLogonTime'; Expression={[String]::join(";", $LastLogonTime)}},LastPasswordChangeTimestamp,@{Name="PasswordExpirationIn (Days)"; Expression={[String]::join(";", $DaysToExpiry)}},@{Name='RecipientTypeDetails'; Expression={[String]::join(";", $RecipientTypeDetails)}},islicensed,@{Name="Licenses"; Expression ={$_.Licenses.AccountSkuId}}
-$Report = $Report+$Information
-}
+$Information
+})
 $CsvPath = Join-Path $ReportPath "Office365MailboxSizeReport.csv"
 $HtmlPath = Join-Path $ReportPath "Office365MailboxSizeReport.html"
 $Report | export-csv $CsvPath -NoTypeInformation


### PR DESCRIPTION
💡 **What:** 
Replaced inefficient O(N^2) array concatenation (`$Report = $Report + $Information`) with the O(N) array subexpression pattern (`$Report = @(foreach(...) { ... $Information })`).

🎯 **Why:** 
Using `+=` to append to an array in PowerShell requires memory reallocation and copying the entire array contents for every single iteration. For scripts dealing with potentially thousands of Office 365 mailboxes, this O(N^2) operation severely degrades performance. Wrapping the loop in an array subexpression passes objects directly to the pipeline, completely avoiding array reallocation overhead.

📊 **Measured Improvement:**
Since the sandbox environment lacks a PowerShell interpreter, I am unable to provide direct benchmarking data or test results. However, this is a well-known, foundational performance antipattern in PowerShell. Replacing `+=` in loops with pipeline accumulation is a guaranteed and dramatic performance improvement for any dataset over a few hundred items, reducing time from quadratic scaling to linear scaling without changing functionality.

---
*PR created automatically by Jules for task [9909670862774835800](https://jules.google.com/task/9909670862774835800) started by @flatlinebb*