### PR TITLE
🧹 Remove dead code from O365_Get-MsolUserLicense.ps1

### DIFF
--- a/O365_Get-MsolUserLicense.ps1
+++ b/O365_Get-MsolUserLicense.ps1
@@ -18,11 +18,6 @@
 $VerbosePreference = 'Continue'    # Makes verbose meldingen zichtbaar : Modify to your needs
 # The Reports will be written to files in the current working directory
 
-# Connect to Microsoft Online IF NEEDED
-#write-host "Connecting to Office 365..."
-#Import-Module MSOnline
-#Connect-MsolService -Credential $Office365credentials
-
 # Get a list of all licences that exist within the tenant
 $licensetype = Get-MsolAccountSku | Where {$_.ConsumedUnits -ge 1}
 


### PR DESCRIPTION
🎯 **What:** Removed the commented-out `Connect to Microsoft Online IF NEEDED` block in `O365_Get-MsolUserLicense.ps1`.
💡 **Why:** The dead code removal is straightforward, improves readability, and avoids confusion.
✅ **Verification:** Verified that the lines were removed and no other code was modified. Safe refactoring since it is purely comment deletion.
✨ **Result:** A cleaner and more maintainable `O365_Get-MsolUserLicense.ps1` script.

---
*PR created automatically by Jules for task [4487471531449424521](https://jules.google.com/task/4487471531449424521) started by @flatlinebb*