### PR TITLE
🧹 Remove dead code from O365_AddToDistributionGroupBulk.ps1

### DIFF
--- a/O365_AddToDistributionGroupBulk.ps1
+++ b/O365_AddToDistributionGroupBulk.ps1
@@ -1,5 +1,4 @@
 $csvlist = read-host "Path of CSV file with member names?"
 
 Import-CSV $csvlist | foreach{Add-DistributionGroupMember -Identity $_.identity -Member $_.members}
-# Import-CSV $csvlist | Get-DistributionGroupMember -Identity $csvlist.identity
 


### PR DESCRIPTION
🎯 **What:** Removed commented-out dead code (`# Import-CSV $csvlist | Get-DistributionGroupMember -Identity $csvlist.identity`) from `O365_AddToDistributionGroupBulk.ps1`.
💡 **Why:** To improve code maintainability and readability by cleaning up obsolete and unnecessary code snippets.
✅ **Verification:** Verified the removal visually and via the code review process. Ensured that the line endings were preserved as CRLF and no temporary scripts were left behind.
✨ **Result:** The script is cleaner and easier to read without any dead code lingering in the comments.

---
*PR created automatically by Jules for task [1126729814091674125](https://jules.google.com/task/1126729814091674125) started by @flatlinebb*