### PR TITLE
🧹 Remove commented-out code in O365_GetDistMembership2.ps1

### DIFF
--- a/O365_GetDistMembership2.ps1
+++ b/O365_GetDistMembership2.ps1
@@ -1,17 +1,6 @@
 $User = read-host -Prompt "Enter User" 
 $DN=$User.DistinguishedName
 "User "+ $User + " is a member of these groups:" 
-# $groups = Get-DistributionGroup
-# $groups | where-object { ( Get-DistributionGroupMember $_ | where-object { $_.Name -eq $User}) } 
 
-#Get-DistributionGroup | select -Property alias | Foreach-Object {
-#    Get-DistributionGroupMember S_.Alias | Foreach-Object {
-#        $_.Name -eq $User
-#    }
-#}
-
-
-#$Mailbox=get-Mailbox user@domain.com
-#$DN=$mailbox.DistinguishedName
 $Filter = "Members -like ""$User"""
 Get-DistributionGroup -ResultSize Unlimited -Filter $Filter


### PR DESCRIPTION
🎯 **What:** Removed three blocks of commented-out code in `O365_GetDistMembership2.ps1` (`# $groups...`, `#Get-DistributionGroup...`, `#$Mailbox...`).
💡 **Why:** The commented-out code is obsolete dead code. Removing it improves the readability and maintainability of the script.
✅ **Verification:**
- Used a custom python script (`fix.py`) to process the file line by line in binary mode to ensure CRLF line endings were preserved and no other lines were modified.
- Verified changes with `git diff --staged` showing only commented lines and some redundant whitespace lines were removed.
- Verified CRLF preservation.
✨ **Result:** The code is cleaner without the dead code blocks, with no functional changes.

---
*PR created automatically by Jules for task [5326252582163848125](https://jules.google.com/task/5326252582163848125) started by @flatlinebb*