### PR TITLE
🧪 Add Pester tests for delete-files in CleanTempFiles_Connor.ps1

### DIFF
--- a/CleanTempFiles_Connor.ps1
+++ b/CleanTempFiles_Connor.ps1
@@ -1,14 +1,4 @@
-﻿
-#setup and time tracking
-$StartDate = Get-Date
-$scriptname = "CleanTempFiles.ps1"
-
-$scriptpath = $MyInvocation.MyCommand.Path
-$dir = Split-Path $scriptpath
-$dir = (Get-Item -Path $dir -Verbose).FullName
-$logdelete = "$dir\delete_files_log.txt"
-
-#deleted files piped to it
+﻿#deleted files piped to it
 function delete-files{
 Param([string]$Extension, [string]$TargetFolder)
     
@@ -27,23 +17,36 @@ Param([string]$Extension, [string]$TargetFolder)
     }
 }
 
+if ($MyInvocation.InvocationName -ne '.') {
 
-##MAIN SETUP FUNCTIONALITY##
-##Target files and Extentions
-$Tgt1 = 'C:\Windows\Logs\CBS\' 
-$ext1 = '*.log'
+    #setup and time tracking
+    $StartDate = Get-Date
+    $scriptname = "CleanTempFiles.ps1"
 
-$Tgt2 = 'C:\Windows\Temp\'
-$ext2 = 'cab_*'
-##executes the deleting function with the target path and the desired extension
-delete-files -TargetFolder $Tgt1 -Extension $ext1
-delete-files -TargetFolder $Tgt2 -Extension $ext2
+    $scriptpath = $MyInvocation.MyCommand.Path
+    $dir = Split-Path $scriptpath
+    $dir = (Get-Item -Path $dir -Verbose).FullName
+    $logdelete = "$dir\delete_files_log.txt"
 
 
-#closing time tracking statements
-$EndDate = Get-Date
-$TimeSpent = New-TimeSpan -Start $StartDate -End $EndDate
-$TotalMinutes = $TimeSpent.TotalMinutes 
-$Data = "${scriptname}, ${TotalMinutes}, ${StartDate}, ${EndDate}"
-$files ="${dir}\timetracking.txt"
-$Data |Out-File -Append $files
+
+    ##MAIN SETUP FUNCTIONALITY##
+    ##Target files and Extentions
+    $Tgt1 = 'C:\Windows\Logs\CBS\'
+    $ext1 = '*.log'
+
+    $Tgt2 = 'C:\Windows\Temp\'
+    $ext2 = 'cab_*'
+    ##executes the deleting function with the target path and the desired extension
+    delete-files -TargetFolder $Tgt1 -Extension $ext1
+    delete-files -TargetFolder $Tgt2 -Extension $ext2
+
+
+    #closing time tracking statements
+    $EndDate = Get-Date
+    $TimeSpent = New-TimeSpan -Start $StartDate -End $EndDate
+    $TotalMinutes = $TimeSpent.TotalMinutes
+    $Data = "${scriptname}, ${TotalMinutes}, ${StartDate}, ${EndDate}"
+    $files ="${dir}\timetracking.txt"
+    $Data |Out-File -Append $files
+}

--- a/tests/CleanTempFiles_Connor.Tests.ps1
+++ b/tests/CleanTempFiles_Connor.Tests.ps1
@@ -1,0 +1,42 @@
+$ScriptPath = "$PSScriptRoot\..\CleanTempFiles_Connor.ps1"
+. $ScriptPath
+
+Describe "delete-files" {
+    It "should find files, log their sizes, and remove them" {
+        # Setup
+        $script:logdelete = "mock_log.txt"
+
+        $mockFile1 = [PSCustomObject]@{
+            FullName = "C:\Fake\Dir\file1.log"
+            Length = 2048
+        }
+        $mockFile2 = [PSCustomObject]@{
+            FullName = "C:\Fake\Dir\file2.log"
+            Length = 1024
+        }
+        $mockFiles = @($mockFile1, $mockFile2)
+
+        # Mocking Get-ChildItem for the target folder search AND for getting file length
+        Mock Get-ChildItem {
+            if ($Path -and $Path -eq "C:\Fake\Dir") {
+                return $mockFiles
+            } else {
+                # It's called on the file object itself in the function: Get-ChildItem $file
+                return $Path
+            }
+        }
+
+        Mock Get-Date { return "1/1/2024 12:00:00 PM" }
+        Mock Out-File {}
+        Mock Remove-Item {}
+
+        # Act
+        delete-files -Extension "*.log" -TargetFolder "C:\Fake\Dir"
+
+        # Assert
+        Assert-MockCalled -CommandName Get-ChildItem -ParameterFilter { $Path -eq "C:\Fake\Dir" -and $Include -eq "*.log" -and $Recurse } -Times 1
+        Assert-MockCalled -CommandName Out-File -ParameterFilter { $Append -and $FilePath -eq "mock_log.txt" } -Times 2
+        Assert-MockCalled -CommandName Remove-Item -ParameterFilter { $Path -eq "C:\Fake\Dir\file1.log" -and $Force -and $Confirm -eq $false } -Times 1
+        Assert-MockCalled -CommandName Remove-Item -ParameterFilter { $Path -eq "C:\Fake\Dir\file2.log" -and $Force -and $Confirm -eq $false } -Times 1
+    }
+}


### PR DESCRIPTION
🎯 **What:** Missing test coverage and Pester mock implementation for the core `delete-files` function in `CleanTempFiles_Connor.ps1`.
📊 **Coverage:** The function is now fully tested by mocking its dependencies:
  - Mocked `Get-ChildItem` handles both searching the target folder and reading file sizes.
  - Mocked `Out-File` ensures logs are "written" safely in memory.
  - Mocked `Remove-Item` asserts that expected files are deleted with `-Force` and `-Confirm:$false`.
✨ **Result:** The codebase gains safety against regressions for this cleanup script, enabling future structural changes with confidence. The main script logic was also updated with a standard dot-sourcing guard to prevent unwanted side-effects during testing.

---
*PR created automatically by Jules for task [12380715132254951749](https://jules.google.com/task/12380715132254951749) started by @flatlinebb*