### PR TITLE
🔒 Secure `$Office365Password` parameter in Get-DistributionGroupMembers.ps1

### DIFF
--- a/Get-DistributionGroupMembers.ps1
+++ b/Get-DistributionGroupMembers.ps1
@@ -7,7 +7,7 @@
 # 
 # To run the script 
 # 
-# .\Get-DistributionGroupMembers.ps1 [-Office365Username admin@xxxxxx.onmicrosoft.com] [-Office365Password Password123]
+# .\Get-DistributionGroupMembers.ps1 [-Office365Username admin@xxxxxx.onmicrosoft.com] [-Office365Password (ConvertTo-SecureString 'Password123' -AsPlainText -Force)]
 # 
 # 
 # Author:                 Alan Byrne 
@@ -21,7 +21,7 @@ Param(
     [Parameter(Position=0, Mandatory=$false, ValueFromPipeline=$true)] 
     [string] $Office365Username, 
     [Parameter(Position=1, Mandatory=$false, ValueFromPipeline=$true)] 
-    [string] $Office365Password 
+    [SecureString] $Office365Password
 ) 
  
 #Constant Variables 
@@ -33,12 +33,10 @@ $arrDLMembers = @{}
 Get-PSSession | Remove-PSSession 
  
 #Did they provide creds?  If not, ask them for it.
-if (([string]::IsNullOrEmpty($Office365Username) -eq $false) -and ([string]::IsNullOrEmpty($Office365Password) -eq $false))
+if (([string]::IsNullOrEmpty($Office365Username) -eq $false) -and ($null -ne $Office365Password))
 {
-    $SecureOffice365Password = ConvertTo-SecureString -AsPlainText $Office365Password -Force     
-     
     #Build credentials object 
-    $Office365Credentials  = New-Object System.Management.Automation.PSCredential $Office365Username, $SecureOffice365Password 
+    $Office365Credentials  = New-Object System.Management.Automation.PSCredential $Office365Username, $Office365Password
 }
 else
 {


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The `Get-DistributionGroupMembers.ps1` script previously accepted the Office 365 password as a plain `[string]`. It has been changed to `[SecureString]`.

⚠️ **Risk:** The potential impact if left unfixed
Passing passwords as plaintext strings allows them to be logged in PowerShell transcripts, event logs, and shell histories, potentially exposing sensitive admin credentials to unauthorized users or logging systems.

🛡️ **Solution:** How the fix addresses the vulnerability
- Changed the `$Office365Password` parameter type to `[SecureString]`.
- Updated the parameter validation logic from `[string]::IsNullOrEmpty` to `$null -ne $Office365Password`.
- Removed the unsafe `ConvertTo-SecureString -AsPlainText` block, as the input is now directly securely handled.
- Updated documentation and parameter comments to reflect the new expected usage for creating the SecureString.

---
*PR created automatically by Jules for task [15497636425644213630](https://jules.google.com/task/15497636425644213630) started by @flatlinebb*