### PR TITLE
⚡ Replace inefficient O(N^2) array concatenation in WAN_speed_test.ps1

### DIFF
--- a/WAN_speed_test.ps1
+++ b/WAN_speed_test.ps1
@@ -117,17 +117,9 @@ $ServerInformation = @(foreach($val in $cons)
 $serverinformation = $serverinformation | Sort-Object -Property distance
 
 #Runs the functions 4 times and takes the highest result.
-$DLResults1 = downloadSpeed($serverinformation[0].url)
-$SpeedResults += @([pscustomobject]@{Speed = $DLResults1;})
-
-$DLResults2 = downloadSpeed($serverinformation[1].url)
-$SpeedResults += @([pscustomobject]@{Speed = $DLResults2;})
-
-$DLResults3 = downloadSpeed($serverinformation[2].url)
-$SpeedResults += @([pscustomobject]@{Speed = $DLResults3;})
-
-$DLResults4 = downloadSpeed($serverinformation[3].url)
-$SpeedResults += @([pscustomobject]@{Speed = $DLResults4;})
+$SpeedResults = @(foreach ($i in 0..3) {
+    [pscustomobject]@{Speed = (downloadSpeed $serverinformation[$i].url)}
+})
 
 $UnsortedResults = $SpeedResults | Sort-Object -Property speed
 $WanSpeed = $UnsortedResults[3].speed


### PR DESCRIPTION
💡 **What:** 
Replaced the repeated array concatenation (`+=`) blocks used for capturing the four `downloadSpeed` function results with an array subexpression wrapper `foreach` assignment (`$SpeedResults = @(foreach ($i in 0..3) { ... })`). 

🎯 **Why:** 
In PowerShell, arrays are immutable. Using the `+=` operator on an array causes PowerShell to create a completely new array in memory, copy all existing items to it, and then add the new item. Doing this inside loops or sequentially as was done here results in an O(N^2) memory operation (reallocations and copies). Assigning the result of a `foreach` loop directly to the array variable prevents this overhead, establishing a single array instantiation. 

📊 **Measured Improvement:** 
Due to the repository's execution environment lacking a PowerShell interpreter natively installed, it was not possible to profile the script locally using `Measure-Command`. However, this `+=` behavior is a well-documented PowerShell anti-pattern. While the small iteration count here (N=4) means the absolute CPU cycles saved are minimal, applying standard O(N) array idioms correctly prevents memory fragmentation and is a best practice universally applied across codebases.

---
*PR created automatically by Jules for task [3236446252027521751](https://jules.google.com/task/3236446252027521751) started by @flatlinebb*