### PR TITLE
🔒 Fix unsafe dynamic execution in Event Error HTML script

### DIFF
--- a/Get_Events_Errors_30days_HTML.ps1
+++ b/Get_Events_Errors_30days_HTML.ps1
@@ -14,4 +14,4 @@ $body = Get-WinEvent -FilterHashTable @{LogName='Application','System'; Level=2;
  
 $body | ConvertTo-HTML -Head $css TimeCreated,LogName,ProviderName,Id,LevelDisplayName,Message -verbose > C:\LogAppView.html 
 
-Start-Process C:\LogAppView.html
+Invoke-Item C:\LogAppView.html

--- a/Get_Events_Errors_30days_HTML.ps1
+++ b/Get_Events_Errors_30days_HTML.ps1
@@ -14,4 +14,4 @@ $body = Get-WinEvent -FilterHashTable @{LogName='Application','System'; Level=2;
  
 $body | ConvertTo-HTML -Head $css TimeCreated,LogName,ProviderName,Id,LevelDisplayName,Message -verbose > C:\LogAppView.html 
 
-Invoke-Expression C:\LogAppView.html 
+Start-Process C:\LogAppView.html


### PR DESCRIPTION
🎯 **What:** Fixed an unsafe dynamic execution vulnerability in `Get_Events_Errors_30days_HTML.ps1`.
⚠️ **Risk:** The previous code used `Invoke-Expression` to open an HTML file (`C:\LogAppView.html`). If an attacker could somehow modify the file path or inject content into the script, `Invoke-Expression` would execute it as arbitrary PowerShell code.
🛡️ **Solution:** Replaced `Invoke-Expression` with `Start-Process`. `Start-Process` securely opens the HTML file with its default handler (like a web browser) without parsing or evaluating the file path as executable PowerShell commands.

---
*PR created automatically by Jules for task [2268077801139180277](https://jules.google.com/task/2268077801139180277) started by @flatlinebb*