### PR TITLE
🧪 Add error tests for Get-PendingReboot core WMI logic

### DIFF
--- a/tests/Get-PendingReboot.Tests.ps1
+++ b/tests/Get-PendingReboot.Tests.ps1
@@ -1,0 +1,25 @@
+$ScriptPath = "$PSScriptRoot\..\Get-PendingReboot.ps1"
+. $ScriptPath
+
+Describe "Get-PendingReboot" {
+    Context "When WMI access fails" {
+        It "Should log a warning and continue when Get-WmiObject throws an error" {
+            Mock Get-WmiObject { throw "Simulated WMI Error" }
+            Mock Write-Warning {}
+
+            Get-PendingReboot -ComputerName "TestPC"
+
+            Assert-MockCalled Write-Warning -Times 1 -ParameterFilter { $Message -like "TestPC: Simulated WMI Error" -or $Message -like "TestPC: *Simulated WMI Error*" }
+        }
+
+        It "Should append error to ErrorLog when -ErrorLog is specified" {
+            Mock Get-WmiObject { throw "Simulated WMI Error" }
+            Mock Write-Warning {}
+            Mock Out-File {}
+
+            Get-PendingReboot -ComputerName "TestPC" -ErrorLog "C:\temp\error.log"
+
+            Assert-MockCalled Out-File -Times 1 -ParameterFilter { $FilePath -eq "C:\temp\error.log" -and $InputObject -like "TestPC,*" }
+        }
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `Get-PendingReboot` script relies heavily on WMI and registry queries within a main `try/catch` block inside a loop. However, there were no automated tests ensuring that WMI access failures are handled correctly.

📊 **Coverage:** What scenarios are now tested
Added Pester unit tests that cover WMI failures using mocked `Get-WmiObject` behavior.
1. When `Get-WmiObject` throws an error, it verifies that `Write-Warning` is called with the expected computer name and error message.
2. It verifies that when the `-ErrorLog` parameter is provided, `Out-File` is correctly called to append the error details to the log file.

✨ **Result:** The improvement in test coverage
The changes significantly improve the test coverage by ensuring the main error-handling logic around remote WMI execution functions as intended, providing confidence that the script will continue gracefully handling failures for individual computers when run in bulk against multiple nodes.

---
*PR created automatically by Jules for task [15137226608083840324](https://jules.google.com/task/15137226608083840324) started by @flatlinebb*