### PR TITLE
🧪 Add Pester tests for Send-WOL.ps1

### DIFF
--- a/tests/Send-WOL.Tests.ps1
+++ b/tests/Send-WOL.Tests.ps1
@@ -1,0 +1,48 @@
+$ScriptPath = "$PSScriptRoot\..\Send-WOL.ps1"
+
+Describe "Send-WOL" {
+    BeforeAll {
+        . $ScriptPath
+    }
+
+    Context "Sending WOL packets" {
+        It "Should successfully send a WOL packet with MAC 00:11:32:21:2D:11 and IP 192.168.8.255" {
+            Mock New-Object {
+                [PSCustomObject]@{
+                    Connect = { param($ip, $port) }
+                    Send    = { param($packet, $length) }
+                }
+            } -ParameterFilter { $TypeName -eq 'System.Net.Sockets.UdpClient' }
+
+            Send-WOL -mac "00:11:32:21:2D:11" -ip "192.168.8.255"
+
+            Assert-MockCalled New-Object -Times 1 -ParameterFilter { $TypeName -eq 'System.Net.Sockets.UdpClient' }
+        }
+
+        It "Should correctly parse various MAC address formats" {
+            Mock New-Object {
+                [PSCustomObject]@{
+                    Connect = { param($ip, $port) }
+                    Send    = { param($packet, $length) }
+                }
+            } -ParameterFilter { $TypeName -eq 'System.Net.Sockets.UdpClient' }
+
+            Send-WOL -mac "00-11-32-21-2D-11" -ip "192.168.8.255"
+            Send-WOL -mac "0011.3221.2D11" -ip "192.168.8.255"
+            Send-WOL -mac "001132212D11" -ip "192.168.8.255"
+
+            Assert-MockCalled New-Object -Times 3 -ParameterFilter { $TypeName -eq 'System.Net.Sockets.UdpClient' }
+        }
+
+        It "Should throw an exception if an invalid short MAC address is provided" {
+            Mock New-Object {
+                [PSCustomObject]@{
+                    Connect = { param($ip, $port) }
+                    Send    = { param($packet, $length) }
+                }
+            } -ParameterFilter { $TypeName -eq 'System.Net.Sockets.UdpClient' }
+
+            { Send-WOL -mac "1234" } | Should -Throw
+        }
+    }
+}


### PR DESCRIPTION
🎯 **What:** Missing test file for `Send-WOL.ps1` function which sends a UDP Wake-On-LAN packet.
📊 **Coverage:** Covered happy paths (valid MAC/IP combinations), edge cases (different valid MAC separators like `:`, `-`, `.`, and none), and error conditions (invalid short MAC addresses).
✨ **Result:** Test coverage for `Send-WOL` is now established without requiring actual network dependencies by effectively mocking the `System.Net.Sockets.UdpClient`.

---
*PR created automatically by Jules for task [848364869435807877](https://jules.google.com/task/848364869435807877) started by @flatlinebb*