### PR TITLE
🔒 Fix plaintext HTTP downloads to prevent MITM attacks

### DIFF
--- a/CCleaner Silent install.txt
+++ b/CCleaner Silent install.txt
@@ -2,7 +2,7 @@ CCleaner Silent Install:
 
 For this get the slim version, its on their website
 
-http://www.ccleaner.com/download/builds
+https://www.ccleaner.com/download/builds
 
 Silent Install;
 

--- a/Comm2005_install.bat
+++ b/Comm2005_install.bat
@@ -137,7 +137,7 @@ REM If the psexec.exe command does not exist, show helpful info
 CLS
 ECHO.
 echo *** No PSEXEC command found on your hard drive. Please download PSTOOLS Suite from here: 
-echo *** http://technet.microsoft.com/en-us/sysinternals/bb896649
+echo *** https://technet.microsoft.com/en-us/sysinternals/bb896649
 echo *** and extract the files in it to your Windows folder or its own folder then add it to PATH
 ECHO *** If you already have PSEXEC on your system, please make sure its location is in the PATH
 ECHO.

--- a/DisableFirewallRemotely.bat
+++ b/DisableFirewallRemotely.bat
@@ -5,7 +5,7 @@ rem - Template which determines OS Type
 rem - 
 rem - This template script can be used to execute the appropriate command for the
 rem - appropriate version of windows. The original code came from the site: 
-rem - http://malektips.com/xp_dos_0025.html 
+rem - https://malektips.com/xp_dos_0025.html
 rem - 
 rem - Script last updated in August 2010. Will require updating with new releases
 rem - of windows. 

--- a/Get-PendingReboot.ps1
+++ b/Get-PendingReboot.ps1
@@ -61,15 +61,15 @@ Function Get-PendingReboot
 
 .LINK
     Component-Based Servicing:
-    http://technet.microsoft.com/en-us/library/cc756291(v=WS.10).aspx
+    https://technet.microsoft.com/en-us/library/cc756291(v=WS.10).aspx
 	
     PendingFileRename/Auto Update:
-    http://support.microsoft.com/kb/2723674
-    http://technet.microsoft.com/en-us/library/cc960241.aspx
-    http://blogs.msdn.com/b/hansr/archive/2006/02/17/patchreboot.aspx
+    https://support.microsoft.com/kb/2723674
+    https://technet.microsoft.com/en-us/library/cc960241.aspx
+    https://blogs.msdn.com/b/hansr/archive/2006/02/17/patchreboot.aspx
 
     SCCM 2012/CCM_ClientSDK:
-    http://msdn.microsoft.com/en-us/library/jj902723.aspx
+    https://msdn.microsoft.com/en-us/library/jj902723.aspx
 
 .NOTES
     Author:  Brian Wilhite

--- a/Rebuild_Icon_Cache.bat
+++ b/Rebuild_Icon_Cache.bat
@@ -1,6 +1,6 @@
 :: Created by: Shawn Brink
-:: http://www.sevenforums.com
-:: Tutorial:  http://www.sevenforums.com/tutorials/49819-icon-cache-rebuild.html
+:: https://www.sevenforums.com
+:: Tutorial:  https://www.sevenforums.com/tutorials/49819-icon-cache-rebuild.html
 
 
 @echo off

--- a/Repair_Windows_Update.bat
+++ b/Repair_Windows_Update.bat
@@ -87,11 +87,11 @@ echo %RegQry%
 Find /i "x86" < CheckOS.txt > StringCheck.txt
 If %%ERRORLEVEL%% == 0 (
     Echo "This is 32 Bit Operating system"
-	wget -nc http://download.windowsupdate.com/windowsupdate/redist/standalone/7.6.7600.320/WindowsUpdateAgent-7.6-x86.exe
+	wget -nc https://download.windowsupdate.com/windowsupdate/redist/standalone/7.6.7600.320/WindowsUpdateAgent-7.6-x86.exe
 	WindowsUpdateAgent-7.6-x86.exe /quiet /norestart /wuforce
 ) ELSE (
     Echo "This is 64 Bit Operating System"
-	wget -nc http://download.windowsupdate.com/windowsupdate/redist/standalone/7.6.7600.320/WindowsUpdateAgent-7.6-x64.exe
+	wget -nc https://download.windowsupdate.com/windowsupdate/redist/standalone/7.6.7600.320/WindowsUpdateAgent-7.6-x64.exe
 	WindowsUpdateAgent-7.6-x64.exe /quiet /norestart /wuforce
 )
  

--- a/Repair_Windows_Update_Advanced.bat
+++ b/Repair_Windows_Update_Advanced.bat
@@ -111,13 +111,13 @@ echo %RegQry%
 Find /i "x86" < CheckOS.txt > StringCheck.txt
 If %%ERRORLEVEL%% == 0 (
     Echo "This is 32 Bit Operating system"
-	wget -nc http://download.windowsupdate.com/windowsupdate/redist/standalone/7.6.7600.320/WindowsUpdateAgent-7.6-x86.exe
+	wget -nc https://download.windowsupdate.com/windowsupdate/redist/standalone/7.6.7600.320/WindowsUpdateAgent-7.6-x86.exe
 	WindowsUpdateAgent-7.6-x86.exe /quiet /norestart /wuforce
 	del /y %USERPROFILE%\Downloads\StringCheck.txt
 	del /y %USERPROFILE%\Downloads\checkOS.txt
 ) ELSE (
     Echo "This is 64 Bit Operating System"
-	wget -nc http://download.windowsupdate.com/windowsupdate/redist/standalone/7.6.7600.320/WindowsUpdateAgent-7.6-x64.exe
+	wget -nc https://download.windowsupdate.com/windowsupdate/redist/standalone/7.6.7600.320/WindowsUpdateAgent-7.6-x64.exe
 	WindowsUpdateAgent-7.6-x64.exe /quiet /norestart /wuforce
 	del /y %USERPROFILE%\Downloads\StringCheck.txt
 	del /y %USERPROFILE%\Downloads\checkOS.txt

--- a/WAN_speed_test.ps1
+++ b/WAN_speed_test.ps1
@@ -62,7 +62,7 @@ Using this method to make the submission to speedtest. Its the only way i could 
 More information for later here: https://support.microsoft.com/en-us/kb/290591 
 #>
 $objXmlHttp = New-Object -ComObject MSXML2.ServerXMLHTTP
-$objXmlHttp.Open("GET", "http://www.speedtest.net/speedtest-config.php", $False)
+$objXmlHttp.Open("GET", "https://www.speedtest.net/speedtest-config.php", $False)
 $objXmlHttp.Send()
 
 #Retrieving the content of the response.
@@ -71,14 +71,14 @@ $objXmlHttp.Send()
 <# 
 Gives me the Latitude and Longitude so i can pick the closer server to me to actually test against. It doesnt seem to automatically do this. 
 Lat and Longitude for tampa at my house are $orilat = 27.9238 and $orilon = -82.3505 
-This is corroborated against: http://www.travelmath.com/cities/Tampa,+FL - It checks out. 
+This is corroborated against: https://www.travelmath.com/cities/Tampa,+FL - It checks out.
 #>
 $oriLat = $content.settings.client.lat
 $oriLon = $content.settings.client.lon
 
 #Making another request. This time to get the server list from the site.
 $objXmlHttp1 = New-Object -ComObject MSXML2.ServerXMLHTTP
-$objXmlHttp1.Open("GET", "http://www.speedtest.net/speedtest-servers.php", $False)
+$objXmlHttp1.Open("GET", "https://www.speedtest.net/speedtest-servers.php", $False)
 $objXmlHttp1.Send()
 
 #Retrieving the content of the response.
@@ -89,7 +89,7 @@ $Cons contains all of the information about every server in the speedtest.net da
 I was going to filter this to US servers only which would speed this up a lot but i know we have overseas partners we run this against. 
 Results returned look like this for each individual server: 
  
-url : http://speedtestnet.rapidsys.com/speedtest/upload.php 
+url : https://speedtestnet.rapidsys.com/speedtest/upload.php
 lat : 27.9709 
 lon : -82.4646 
 name : Tampa, FL 

--- a/WUFix_Install.ps1
+++ b/WUFix_Install.ps1
@@ -1,14 +1,14 @@
-Invoke-WebRequest 'http://download.windowsupdate.com/d/msdownload/update/software/updt/2015/04/windows6.1-kb3020369-x64_5393066469758e619f21731fc31ff2d109595445.msu' -OutFile 'windows6.1-kb3020369-x64_5393066469758e619f21731fc31ff2d109595445.msu'
+Invoke-WebRequest 'https://download.windowsupdate.com/d/msdownload/update/software/updt/2015/04/windows6.1-kb3020369-x64_5393066469758e619f21731fc31ff2d109595445.msu' -OutFile 'windows6.1-kb3020369-x64_5393066469758e619f21731fc31ff2d109595445.msu'
 wusa.exe windows6.1-kb3020369-x64_5393066469758e619f21731fc31ff2d109595445.msu /quiet /norestart
 
-Invoke-WebRequest 'http://download.windowsupdate.com/d/msdownload/update/software/updt/2016/02/windows6.1-kb3138612-x64_f7b1de8ea7cf8faf57b0138c4068d2e899e2b266.msu' -OutFile 'windows6.1-kb3138612-x64_f7b1de8ea7cf8faf57b0138c4068d2e899e2b266.msu'
+Invoke-WebRequest 'https://download.windowsupdate.com/d/msdownload/update/software/updt/2016/02/windows6.1-kb3138612-x64_f7b1de8ea7cf8faf57b0138c4068d2e899e2b266.msu' -OutFile 'windows6.1-kb3138612-x64_f7b1de8ea7cf8faf57b0138c4068d2e899e2b266.msu'
 wusa.exe windows6.1-kb3138612-x64_f7b1de8ea7cf8faf57b0138c4068d2e899e2b266.msu /quiet /norestart
 
-Invoke-WebRequest 'http://download.windowsupdate.com/d/msdownload/update/software/secu/2016/04/windows6.1-kb3145739-x64_b9ae7ee29555dce4d1a225fd1324176a2538178a.msu' -OutFile 'windows6.1-kb3145739-x64_b9ae7ee29555dce4d1a225fd1324176a2538178a.msu'
+Invoke-WebRequest 'https://download.windowsupdate.com/d/msdownload/update/software/secu/2016/04/windows6.1-kb3145739-x64_b9ae7ee29555dce4d1a225fd1324176a2538178a.msu' -OutFile 'windows6.1-kb3145739-x64_b9ae7ee29555dce4d1a225fd1324176a2538178a.msu'
 wusa.exe windows6.1-kb3145739-x64_b9ae7ee29555dce4d1a225fd1324176a2538178a.msu /quiet /norestart
 
-Invoke-WebRequest 'http://download.windowsupdate.com/d/msdownload/update/software/updt/2016/09/windows6.1-kb3172605-x64_2bb9bc55f347eee34b1454b50c436eb6fd9301fc.msu' -OutFile 'windows6.1-kb3172605-x64_2bb9bc55f347eee34b1454b50c436eb6fd9301fc.msu'
+Invoke-WebRequest 'https://download.windowsupdate.com/d/msdownload/update/software/updt/2016/09/windows6.1-kb3172605-x64_2bb9bc55f347eee34b1454b50c436eb6fd9301fc.msu' -OutFile 'windows6.1-kb3172605-x64_2bb9bc55f347eee34b1454b50c436eb6fd9301fc.msu'
 wusa.exe windows6.1-kb3172605-x64_2bb9bc55f347eee34b1454b50c436eb6fd9301fc.msu /quiet /norestart
 
-Invoke-WebRequest 'http://download.windowsupdate.com/windowsupdate/redist/standalone/7.6.7600.320/WindowsUpdateAgent-7.6-x64.exe' -OutFile 'WindowsUpdateAgent-7.6-x64.exe'
+Invoke-WebRequest 'https://download.windowsupdate.com/windowsupdate/redist/standalone/7.6.7600.320/WindowsUpdateAgent-7.6-x64.exe' -OutFile 'WindowsUpdateAgent-7.6-x64.exe'
 WindowsUpdateAgent-7.6-x64.exe /quiet /norestart /wuforce

--- a/WUFix_Install_v2.ps1
+++ b/WUFix_Install_v2.ps1
@@ -1,23 +1,23 @@
 $Client = New-Object System.Net.WebClient
-$Client.DownloadFile('http://download.windowsupdate.com/d/msdownload/update/software/updt/2015/04/windows6.1-kb3020369-x64_5393066469758e619f21731fc31ff2d109595445.msu', @"C:\temp\windows6.1-kb3020369-x64_5393066469758e619f21731fc31ff2d109595445.msu")
+$Client.DownloadFile('https://download.windowsupdate.com/d/msdownload/update/software/updt/2015/04/windows6.1-kb3020369-x64_5393066469758e619f21731fc31ff2d109595445.msu', @"C:\temp\windows6.1-kb3020369-x64_5393066469758e619f21731fc31ff2d109595445.msu")
 wusa.exe "C:\temp\windows6.1-kb3020369-x64_5393066469758e619f21731fc31ff2d109595445.msu" /quiet /norestart
 
 
 $Client = New-Object System.Net.WebClient
-$Client.DownloadFile('http://download.windowsupdate.com/d/msdownload/update/software/updt/2016/02/windows6.1-kb3138612-x64_f7b1de8ea7cf8faf57b0138c4068d2e899e2b266.msuexe', 'windows6.1-kb3138612-x64_f7b1de8ea7cf8faf57b0138c4068d2e899e2b266.msu')
+$Client.DownloadFile('https://download.windowsupdate.com/d/msdownload/update/software/updt/2016/02/windows6.1-kb3138612-x64_f7b1de8ea7cf8faf57b0138c4068d2e899e2b266.msuexe', 'windows6.1-kb3138612-x64_f7b1de8ea7cf8faf57b0138c4068d2e899e2b266.msu')
 wusa.exe windows6.1-kb3138612-x64_f7b1de8ea7cf8faf57b0138c4068d2e899e2b266.msu /quiet /norestart
 
 
 $Client = New-Object System.Net.WebClient
-$Client.DownloadFile('http://download.windowsupdate.com/d/msdownload/update/software/secu/2016/04/windows6.1-kb3145739-x64_b9ae7ee29555dce4d1a225fd1324176a2538178a.msu', 'windows6.1-kb3145739-x64_b9ae7ee29555dce4d1a225fd1324176a2538178a.msu')
+$Client.DownloadFile('https://download.windowsupdate.com/d/msdownload/update/software/secu/2016/04/windows6.1-kb3145739-x64_b9ae7ee29555dce4d1a225fd1324176a2538178a.msu', 'windows6.1-kb3145739-x64_b9ae7ee29555dce4d1a225fd1324176a2538178a.msu')
 wusa.exe windows6.1-kb3145739-x64_b9ae7ee29555dce4d1a225fd1324176a2538178a.msu /quiet /norestart
 
 
 $Client = New-Object System.Net.WebClient
-$Client.DownloadFile('http://download.windowsupdate.com/d/msdownload/update/software/updt/2016/09/windows6.1-kb3172605-x64_2bb9bc55f347eee34b1454b50c436eb6fd9301fc.msu', 'windows6.1-kb3172605-x64_2bb9bc55f347eee34b1454b50c436eb6fd9301fc.msu')
+$Client.DownloadFile('https://download.windowsupdate.com/d/msdownload/update/software/updt/2016/09/windows6.1-kb3172605-x64_2bb9bc55f347eee34b1454b50c436eb6fd9301fc.msu', 'windows6.1-kb3172605-x64_2bb9bc55f347eee34b1454b50c436eb6fd9301fc.msu')
 wusa.exe windows6.1-kb3172605-x64_2bb9bc55f347eee34b1454b50c436eb6fd9301fc.msu /quiet /norestart
 
 
 $Client = New-Object System.Net.WebClient
-$Client.DownloadFile('http://download.windowsupdate.com/windowsupdate/redist/standalone/7.6.7600.320/WindowsUpdateAgent-7.6-x64.exe', 'WindowsUpdateAgent-7.6-x64.exe')
+$Client.DownloadFile('https://download.windowsupdate.com/windowsupdate/redist/standalone/7.6.7600.320/WindowsUpdateAgent-7.6-x64.exe', 'WindowsUpdateAgent-7.6-x64.exe')
 WindowsUpdateAgent-7.6-x64.exe /quiet /norestart /wuforce

--- a/WUFix_Links.txt
+++ b/WUFix_Links.txt
@@ -1,5 +1,5 @@
-http://download.windowsupdate.com/d/msdownload/update/software/updt/2015/04/windows6.1-kb3020369-x64_5393066469758e619f21731fc31ff2d109595445.msu
-http://download.windowsupdate.com/d/msdownload/update/software/updt/2016/02/windows6.1-kb3138612-x64_f7b1de8ea7cf8faf57b0138c4068d2e899e2b266.msu
-http://download.windowsupdate.com/d/msdownload/update/software/secu/2016/04/windows6.1-kb3145739-x64_b9ae7ee29555dce4d1a225fd1324176a2538178a.msu
-http://download.windowsupdate.com/d/msdownload/update/software/updt/2016/09/windows6.1-kb3172605-x64_2bb9bc55f347eee34b1454b50c436eb6fd9301fc.msu
-http://download.windowsupdate.com/windowsupdate/redist/standalone/7.6.7600.320/WindowsUpdateAgent-7.6-x64.exe
+https://download.windowsupdate.com/d/msdownload/update/software/updt/2015/04/windows6.1-kb3020369-x64_5393066469758e619f21731fc31ff2d109595445.msu
+https://download.windowsupdate.com/d/msdownload/update/software/updt/2016/02/windows6.1-kb3138612-x64_f7b1de8ea7cf8faf57b0138c4068d2e899e2b266.msu
+https://download.windowsupdate.com/d/msdownload/update/software/secu/2016/04/windows6.1-kb3145739-x64_b9ae7ee29555dce4d1a225fd1324176a2538178a.msu
+https://download.windowsupdate.com/d/msdownload/update/software/updt/2016/09/windows6.1-kb3172605-x64_2bb9bc55f347eee34b1454b50c436eb6fd9301fc.msu
+https://download.windowsupdate.com/windowsupdate/redist/standalone/7.6.7600.320/WindowsUpdateAgent-7.6-x64.exe

--- a/WUFix_Test.ps1
+++ b/WUFix_Test.ps1
@@ -1,2 +1,2 @@
 $WebClient = New-Object System.Net.WebClient
-$WebClient.DownloadFile("http://download.windowsupdate.com/d/msdownload/update/software/updt/2015/04/windows6.1-kb3020369-x64_5393066469758e619f21731fc31ff2d109595445.msu","c:\temp\windows6.1-kb3020369-x64_5393066469758e619f21731fc31ff2d109595445.msu")
+$WebClient.DownloadFile("https://download.windowsupdate.com/d/msdownload/update/software/updt/2015/04/windows6.1-kb3020369-x64_5393066469758e619f21731fc31ff2d109595445.msu","c:\temp\windows6.1-kb3020369-x64_5393066469758e619f21731fc31ff2d109595445.msu")

--- a/WindowsUpdateFix.txt
+++ b/WindowsUpdateFix.txt
@@ -1,5 +1,5 @@
-http://download.windowsupdate.com/windowsupdate/redist/standalone/7.6.7600.320/WindowsUpdateAgent-7.6-x64.exe
-http://download.windowsupdate.com/d/msdownload/update/software/updt/2015/04/windows6.1-kb3020369-x64_5393066469758e619f21731fc31ff2d109595445.msu
-http://download.windowsupdate.com/d/msdownload/update/software/updt/2016/02/windows6.1-kb3138612-x64_f7b1de8ea7cf8faf57b0138c4068d2e899e2b266.msu
-http://download.windowsupdate.com/d/msdownload/update/software/secu/2016/04/windows6.1-kb3145739-x64_b9ae7ee29555dce4d1a225fd1324176a2538178a.msu
-http://download.windowsupdate.com/d/msdownload/update/software/updt/2016/09/windows6.1-kb3172605-x64_2bb9bc55f347eee34b1454b50c436eb6fd9301fc.msu
+https://download.windowsupdate.com/windowsupdate/redist/standalone/7.6.7600.320/WindowsUpdateAgent-7.6-x64.exe
+https://download.windowsupdate.com/d/msdownload/update/software/updt/2015/04/windows6.1-kb3020369-x64_5393066469758e619f21731fc31ff2d109595445.msu
+https://download.windowsupdate.com/d/msdownload/update/software/updt/2016/02/windows6.1-kb3138612-x64_f7b1de8ea7cf8faf57b0138c4068d2e899e2b266.msu
+https://download.windowsupdate.com/d/msdownload/update/software/secu/2016/04/windows6.1-kb3145739-x64_b9ae7ee29555dce4d1a225fd1324176a2538178a.msu
+https://download.windowsupdate.com/d/msdownload/update/software/updt/2016/09/windows6.1-kb3172605-x64_2bb9bc55f347eee34b1454b50c436eb6fd9301fc.msu

--- a/show_uptime.bat
+++ b/show_uptime.bat
@@ -53,7 +53,7 @@ REM If the uptime.exe or systeminfo.exe commands does not exist, show helpful in
 CLS
 ECHO.
 echo *** No UPTIME or SYSTEMINFO commands found. Please download UPTIME from here: 
-echo *** http://support.microsoft.com/kb/232243
+echo *** https://support.microsoft.com/kb/232243
 echo *** and place in your Windows folder
 ECHO.
 pause

--- a/silent_install_master_menu.bat
+++ b/silent_install_master_menu.bat
@@ -207,7 +207,7 @@ GOTO MENU
 :Selection15
 REM REM Launch the Windows Update website in the default browser.
 ECHO Launching Windows Update website
-start http://www.update.microsoft.com
+start https://www.update.microsoft.com
 GOTO QUIT
 
 :Selection16


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Multiple files (`WUFix_Install.ps1`, `Repair_Windows_Update.bat`, etc.) downloaded executables (`.msu`, `.exe`) using plaintext HTTP (specifically from `http://download.windowsupdate.com`).

⚠️ **Risk:** The potential impact if left unfixed
Downloading executables over plaintext HTTP leaves the user vulnerable to Man-In-The-Middle (MITM) attacks, where an attacker could intercept the unencrypted network traffic and replace the legitimate update package with malware.

🛡️ **Solution:** How the fix addresses the vulnerability
Replaced all instances of `http://download.windowsupdate.com` with `https://download.windowsupdate.com` across the codebase.
Additionally, updated multiple other third-party plaintext `http://` references (e.g., CCleaner downloads, speedtest.net, Microsoft Support links) to `https://` to enforce secure transit across the repository.
Care was taken to revert one mass replacement against an internal domain (`http://logonscriptmgr/default.aspx`) as internal services often lack SSL/TLS and might break if forced to HTTPS.

**Note:** Since the development environment does not support executing native Windows Batch or PowerShell scripts, functional testing could not be automated. A code review verified the changes visually using `git diff`.

---
*PR created automatically by Jules for task [6629548684577246903](https://jules.google.com/task/6629548684577246903) started by @flatlinebb*